### PR TITLE
fix: Require contact info for in-store pickup orders

### DIFF
--- a/src/main/java/com/nhom4/nhtsstore/ui/pointOfSale/InvoicePanel.java
+++ b/src/main/java/com/nhom4/nhtsstore/ui/pointOfSale/InvoicePanel.java
@@ -557,6 +557,13 @@ public class InvoicePanel extends javax.swing.JPanel implements RoutablePanel {
                     isFieldEmpty(txtAddress, "Address is required")) {
                 return false;
             }
+        } else {
+            // Pickup validation - require at least contact method for customer identification
+            if (txtEmail.getText().trim().isEmpty() && txtPhoneNumber.getText().trim().isEmpty()) {
+                showError("Either email or phone number is required for customer identification");
+                txtPhoneNumber.requestFocus();
+                return false;
+            }
         }
 
         if (cart.getItems().isEmpty()) {


### PR DESCRIPTION
- Add validation to require either email or phone number for in-store pickup orders
- Prevent customer identification issues when customers have duplicate names
- Display appropriate error message when contact information is missing
- Keep address field optional for pickup orders